### PR TITLE
Use cmake's find_package for gnutls

### DIFF
--- a/src/encoders/CMakeLists.txt
+++ b/src/encoders/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+find_package(GnuTLS REQUIRED)
+
 # generic Linux option
 add_compile_options("-fPIC")
 
@@ -30,7 +32,7 @@ target_link_libraries(iso15118
     PRIVATE
         cb_exi_codec
     PUBLIC
-        gnutls
+        GnuTLS::GnuTLS
 )
 
 set_target_properties (iso15118 PROPERTIES


### PR DESCRIPTION
This updates the CMakelists.txt to use `find_package()` to find gnutls, which it was failing to do when building on macos.

Tested on macos (gnutls installed via `brew install gnutls`) and Ubuntu 24.04 (gnutls installed via `apt install libgnutls28-dev`).

Support for finding gnutls was [added in cmake 3.16](https://cmake.org/cmake/help/latest/module/FindGnuTLS.html), so hopefully this shouldn't cause any build system compatibility issues.